### PR TITLE
2018 Calibration runs

### DIFF
--- a/logs/a1_log.txt
+++ b/logs/a1_log.txt
@@ -26,4 +26,35 @@
 10302	brianclark	roofpulse	Hpol, ICL pulser, pointed at A2/A5
 10303	brianclark	roofpulse	Hpol, ICL pulser, pulser on 23:20:37 Jan 21 UTC, pointed at A2/A5
 11535	brianclark	deeppulse	See DocDB 1667; pulse date is June 25 2018; hole 22 shallow 21:28:00-21:43:00 UTC; hole shallow 22 22:03:00-21:18:00 UTC; hole 1 shallow 22:23:42-22:53:42 UTC
+12816	myoungchulkim	deeppulse	See DocDB 1731 and 1738, presented by BK Shin
+13221	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13222	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13223	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13229	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13230	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13231	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13241	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13242	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13248	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13249	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13250	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13258	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13259	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13260	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13261	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13262	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13263	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13264	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13265	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13266	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13267	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13268	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13275	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13276	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13285	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13286	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13302	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13303	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13304	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13305	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
 14256	yuepan	incomplete	may be incomplete

--- a/logs/a2_log.txt
+++ b/logs/a2_log.txt
@@ -24,6 +24,35 @@
 9847	brianclark	roofpulse	Hpol, ICL pulser, pointed at A2/A5
 9848	brianclark	roofpulse	Hpol, ICL pulser, pulser on 23:20:37 Jan 21 UTC, pointed at A2/A5
 11076	brianclark	deeppulse	See DocDB 1667; pulse date is June 25 2018; hole 22 shallow 21:28:00-21:43:00 UTC; hole shallow 22 22:03:00-21:18:00 UTC; hole 1 shallow 22:23:42-22:53:42 UTC
+12189	myoungchulkim	deeppulse	See DocDB 1731 and 1738, presented by BK Shin
+12549	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12550	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12551	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12557	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12558	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12559	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12568	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12569	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12575	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12576	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12577	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12585	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12586	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12587	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12588	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12589	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12590	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12591	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12592	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12599	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12600	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12601	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12609	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12610	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12611	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12626	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12627	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+12628	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
 12842	yuepan	trigger delay study	D5 Vpol attenuation sweep 0 to 31 dB with a step of 1 dB.
 12843	yuepan	trigger delay study	D5 Vpol attenuation sweep 0 to 31 dB with a step of 1 dB.
 12844	yuepan	trigger delay study	D5 Vpol attenuation sweep 0 to 31 dB with a step of 1 dB.

--- a/logs/a2_log.txt
+++ b/logs/a2_log.txt
@@ -25,6 +25,7 @@
 9848	brianclark	roofpulse	Hpol, ICL pulser, pulser on 23:20:37 Jan 21 UTC, pointed at A2/A5
 11076	brianclark	deeppulse	See DocDB 1667; pulse date is June 25 2018; hole 22 shallow 21:28:00-21:43:00 UTC; hole shallow 22 22:03:00-21:18:00 UTC; hole 1 shallow 22:23:42-22:53:42 UTC
 12189	myoungchulkim	deeppulse	See DocDB 1731 and 1738, presented by BK Shin
+12446	myoungchulkim	deeppulse	Don't have a detail record
 12549	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
 12550	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
 12551	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
@@ -85,13 +86,3 @@
 12871	yuepan	trigger delay study	D5 Vpol attenuation sweep 0 to 31 dB with a step of 1 dB.
 12872	yuepan	trigger delay study	D5 Vpol attenuation sweep 0 to 31 dB with a step of 1 dB.
 12873	yuepan	trigger delay study	D5 Vpol attenuation sweep 0 to 31 dB with a step of 1 dB.
-
-
-
-
-
-
-
-
-
-

--- a/logs/a3_log.txt
+++ b/logs/a3_log.txt
@@ -31,6 +31,7 @@
 12690	yuepan	bad	In glitch mode
 12691	yuepan	bad	In glitch mode
 12692	yuepan	bad	In glitch mode
+12885	myoungchulkim	deeppulse	Don't have a detail record
 13000	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
 13001	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
 13002	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31

--- a/logs/a3_log.txt
+++ b/logs/a3_log.txt
@@ -21,6 +21,7 @@
 12297	yuepan	bad	In glitch mode
 12298	yuepan	bad	In glitch mode
 12300	yuepan	bad	In glitch mode
+12661	myoungchulkim	deeppulse	See DocDB 1731 and 1738, presented by BK Shin
 12684	yuepan	bad	In glitch mode
 12685	yuepan	bad	In glitch mode
 12686	yuepan	bad	In glitch mode
@@ -30,4 +31,30 @@
 12690	yuepan	bad	In glitch mode
 12691	yuepan	bad	In glitch mode
 12692	yuepan	bad	In glitch mode
+13000	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13001	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13002	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13003	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13009	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13010	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13011	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13022	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13023	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13029	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13030	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13031	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13039	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13040	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13041	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13042	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13043	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13044	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13052	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13053	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13061	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13062	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13063	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13078	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13079	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+13080	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
 13997	yuepan	incomplete	may be incomplete

--- a/logs/a4_log.txt
+++ b/logs/a4_log.txt
@@ -68,6 +68,27 @@
 3244	brianclark	deeppulse	Hole 1 Deep, 10:21:29 to 10:28:30 AM NZT; Att [48, 50, 51, 48, 60, 53, 57, 62, 48, 49, 48, 52, 52, 48, 48, 53]
 3245	brianclark	deeppulse	Hole 1 Deep, ~10:20 to 10:32 AM NZT; Att [48, 50, 51, 48, 60, 53, 57, 62, 48, 49, 48, 52, 52, 48, 48, 53]
 4445	brianclark	deeppulse	See DocDB 1667; pulse date is June 25 2018; hole 22 shallow 21:28:00-21:43:00 UTC; hole shallow 22 22:03:00-21:18:00 UTC; hole 1 shallow 22:23:42-22:53:42 UTC. Att [36,38,39,36,48,41,45,50,36,37,36,40,40,36,36,41]
+5704	myoungchulkim	deeppulse	See DocDB 1731 and 1738, presented by BK Shin
+6109	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6110	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6111	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6117	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6118	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6119	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6128	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6129	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6135	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6136	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6137	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6154	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6155	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6162	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6163	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6164	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6165	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6179	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6180	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+6181	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
 10123	benHokansonFasig	bad	No clear explanation
 10124	benHokansonFasig	bad	No clear explanation
 10125	benHokansonFasig	bad	No clear explanation

--- a/logs/a5_log.txt
+++ b/logs/a5_log.txt
@@ -59,4 +59,25 @@
 2355	brianclark	deeppulse	Hole 1 Deep, 10:21:29 to 10:28:30 AM NZT; Att [19,23,22,16,18,24,17,18,28,29,21,27,23,26,16,16]
 2356	brianclark	deeppulse	Hole 1 Deep, ~10:20 to 10:32 AM NZT; Att [19,23,22,16,18,24,17,18,28,29,21,27,23,26,16,16]
 3629	brianclark	deeppulse	See DocDB 1667; pulse date is June 25 2018; hole 22 shallow 21:28:00-21:43:00 UTC; hole shallow 22 22:03:00-21:18:00 UTC; hole 1 shallow 22:23:42-22:53:42 UTC. Nominal attenuation.
+3963	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+3964	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+3965	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+3971	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+3972	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+3973	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+3982	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+3983	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+3988	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+3989	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+3990	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+4009	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+4010	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+4018	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+4019	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+4020	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+4021	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+4036	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+4037	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+4038	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
+4039	myoungchulkim	spicecore	See DocDB 1784, 2018-12-23 to 2018-12-31
 4456	lizFriedman	bad	soft and cal rate dropped because of overlapping of cal and soft events


### PR DESCRIPTION
1. 2018/11/08 deep pulser runs

Related slide: [DB1731](https://aradocs.wipac.wisc.edu/cgi-bin/DocDB/ShowDocument?docid=1731) and [DB1738](https://aradocs.wipac.wisc.edu/cgi-bin/DocDB/ShowDocument?docid=1738)

2. 2018/12/23 ~ 31 SPICE core runs

Related slide: [DB1784](https://aradocs.wipac.wisc.edu/0017/001784/002/spiceCoreSummary.pdf)
You can find a run list from PDF